### PR TITLE
Refresh Token Key Change

### DIFF
--- a/lib/endpoints/oauth.js
+++ b/lib/endpoints/oauth.js
@@ -53,7 +53,7 @@ module.exports = class OAuth {
       grant_type: 'refresh_token',
       client_id: clientId,
       client_secret: clientSecret,
-      refreshToken: refreshToken,
+      refresh_token: refreshToken,
     };
     return (await endpoint.post('token', data)).data;
   }

--- a/lib/endpoints/webhooks.js
+++ b/lib/endpoints/webhooks.js
@@ -72,7 +72,7 @@ module.exports = class Webhooks extends Endpoint {
    */
   async register(url) {
     try {
-      data = { account_id: this._accountId, url: url };
+      var data = { account_id: this._accountId, url: url };
       return new Webhook(await this.post('', data));
     } catch (err) {
       console.log(err);


### PR DESCRIPTION
As per the documentation on the Monzo website, the refresh token key on the data object needs changing from refreshToken to refresh_token. once this change is made, it works again. otherwise you get a 400 response.

Could you also please push this change to npm as I have a node-red node that depends on this.
Many Thanks!